### PR TITLE
Adding Docker-Compose and changing readme to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ This image includes an `owserver` and `owhttpd` installation for using [OneWire/
 ## Usage
 
 ### Default Config
-
+Basic execution using USB OneWire device like DS9490R.
 ```bash
 docker run -it --name owfs --device /dev/bus/usb -p 2122:2121 -d mneundorfer/owserver:latest
+```
+#### Docker-Compose
+Build on your own computer and run as docker-compose service. Config could be changed to use e.g. I2C devices.
+```bash
+git clone https://github.com/mneundorfer/owserver
+cd owserver
+docker-compose up
 ```
 
 ### Custom OWFS Config

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Basic execution using USB OneWire device like DS9490R.
 docker run -it --name owfs --device /dev/bus/usb -p 2122:2121 -d mneundorfer/owserver:latest
 ```
 #### Docker-Compose
-Build on your own computer and run as docker-compose service. Config could be changed to use e.g. I2C devices.
+Build on your own container and run as docker-compose service. Config could be changed to use e.g. I2C devices.
+
 ```bash
 git clone https://github.com/mneundorfer/owserver
 cd owserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  owfs:
+    build: .
+    devices:
+      - /dev/bus/usb/
+    ports:
+      - 2122:2121
+      - 4304:4304

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
     ports:
       - 2122:2121
       - 4304:4304
+    volumes:
+      - ./owfs.conf:/etc/owfs.conf:ro


### PR DESCRIPTION
Creating Docker-Compose example which will Build local, open 2122/4304 and uses ./owfs.conf as config. The Readme explains the usage when cloning the repo to local and let docker build itselfe. 
The local build could be exchanged by repo-pulling mneundorfer/owserver.